### PR TITLE
remove object change logging because not necessary

### DIFF
--- a/src/yahka.ioBroker-adapter.ts
+++ b/src/yahka.ioBroker-adapter.ts
@@ -28,7 +28,6 @@ export class TIOBrokerAdapter implements hkBridge.IHomeKitBridgeBindingFactory {
 
     constructor(private adapter:ioBroker.IAdapter, private controllerPath) {
         adapter.on('ready', this.adapterReady.bind(this));
-        adapter.on('objectChange', this.handleObjectChange.bind(this));
         adapter.on('stateChange', this.handleState.bind(this));
         adapter.on('message', this.handleMessage.bind(this));
         adapter.on('unload', this.handleUnload.bind(this));
@@ -87,11 +86,6 @@ export class TIOBrokerAdapter implements hkBridge.IHomeKitBridgeBindingFactory {
     private handleHAPLogEvent(message) {
         if (this.verboseHAPLogging)
             this.adapter.log.debug(message);
-    }
-
-    private handleObjectChange(id:string, obj:ioBroker.IObject) {
-        // Warning, obj can be null if it was deleted
-        this.adapter.log.info('objectChange ' + id + ' ' + JSON.stringify(obj));
     }
 
     private handleState(id:string, state:ioBroker.IState) {

--- a/yahka.ioBroker-adapter.js
+++ b/yahka.ioBroker-adapter.js
@@ -18,7 +18,6 @@ var TIOBrokerAdapter = (function () {
         this.devices = [];
         this.verboseHAPLogging = false;
         adapter.on('ready', this.adapterReady.bind(this));
-        adapter.on('objectChange', this.handleObjectChange.bind(this));
         adapter.on('stateChange', this.handleState.bind(this));
         adapter.on('message', this.handleMessage.bind(this));
         adapter.on('unload', this.handleUnload.bind(this));

--- a/yahka.ioBroker-adapter.js
+++ b/yahka.ioBroker-adapter.js
@@ -71,9 +71,6 @@ var TIOBrokerAdapter = (function () {
         if (this.verboseHAPLogging)
             this.adapter.log.debug(message);
     };
-    TIOBrokerAdapter.prototype.handleObjectChange = function (id, obj) {
-        this.adapter.log.info('objectChange ' + id + ' ' + JSON.stringify(obj));
-    };
     TIOBrokerAdapter.prototype.handleState = function (id, state) {
         var notifyArray = this.stateToEventMap.get(id);
         if (!notifyArray) {


### PR DESCRIPTION
- removes logging of object change
- addresses #53 
- adapter still logs sensitive information when stopping/restarting the adapter like
```
2018-10-02 18:00:49.285  - [31merror[39m: Caught by controller[0]: 2018-10-02T16:00:42.282Z socket.io-client:url parse http://127.0.0.1:9001
2018-10-02 18:00:49.286  - [31merror[39m: Caught by controller[1]: 2018-10-02T16:00:42.295Z socket.io-client new io instance for http://127.0.0.1:9001
2018-10-02 18:00:49.286  - [31merror[39m: Caught by controller[2]: 2018-10-02T16:00:42.303Z socket.io-client:manager readyState closed
2018-10-02 18:00:49.287  - [31merror[39m: Caught by controller[3]: 2018-10-02T16:00:42.304Z socket.io-client:manager opening http://127.0.0.1:9001
2018-10-02 18:00:49.287  - [31merror[39m: Caught by controller[4]: 2018-10-02T16:00:42.312Z engine.io-client:socket creating transport "polling"
2018-10-02 18:00:49.287  - [31merror[39m: Caught by controller[5]: 2018-10-02T16:00:42.318Z engine.io-client:polling polling
2018-10-02 18:00:49.288  - [31merror[39m: Caught by controller[6]: 2018-10-02T16:00:42.319Z engine.io-client:polling-xhr xhr poll
2018-10-02 18:00:49.288  - [31merror[39m: Caught by controller[7]: 2018-10-02T16:00:42.325Z engine.io-client:polling-xhr xhr open GET: http://127.0.0.1:9001/socket.io/?EIO=3&transport=polling&t=MOrWfLH&b64=1
2018-10-02 18:00:49.288  - [31merror[39m: Caught by controller[8]: 2018-10-02T16:00:42.329Z engine.io-client:polling-xhr xhr data null
2018-10-02 18:00:49.289  - [31merror[39m: Caught by controller[9]: 2018-10-02T16:00:42.371Z engine.io-client:socket setting transport polling
2018-10-02 18:00:49.289  - [31merror[39m: Caught by controller[10]: 2018-10-02T16:00:42.372Z socket.io-client:manager connect attempt will timeout after 20000
2018-10-02 18:00:49.289  - [31merror[39m: Caught by controller[11]: 2018-10-02T16:00:42.379Z socket.io-client:manager readyState opening
2018-10-02 18:00:49.289  - [31merror[39m: Caught by controller[12]: 2018-10-02T16:00:42.440Z engine.io-client:polling polling got data 96:0{"sid":"hqP-Ug2UiFlPpWXMAABZ","upgrades":["websocket"],"pingInterval":25000,"pingTimeout":5000}2:40
2018-10-02 18:00:49.290  - [31merror[39m: Caught by controller[13]: 2018-10-02T16:00:42.444Z engine.io-client:socket socket receive: type "open", data "{"sid":"hqP-Ug2UiFlPpWXMAABZ","upgrades":["websocket"],"pingInterval":25000,"pingTimeout":5000}"
2018-10-02 18:00:49.290  - [31merror[39m: Caught by controller[14]: 2018-10-02T16:00:42.447Z engine.io-client:socket socket open
2018-10-02 18:00:49.290  - [31merror[39m: Caught by controller[15]: 2018-10-02T16:00:42.448Z socket.io-client:manager open
2018-10-02 18:00:49.291  - [31merror[39m: Caught by controller[16]: 2018-10-02T16:00:42.449Z socket.io-client:manager cleanup
2018-10-02 18:00:49.291  - [31merror[39m: Caught by controller[17]: 2018-10-02T16:00:42.454Z socket.io-client:socket transport is open - connecting
2018-10-02 18:00:49.291  - [31merror[39m: Caught by controller[18]: 2018-10-02T16:00:42.455Z engine.io-client:socket starting upgrade probes
2018-10-02 18:00:49.292  - [31merror[39m: Caught by controller[19]: 2018-10-02T16:00:42.457Z engine.io-client:socket probing transport "websocket"
2018-10-02 18:00:49.292  - [31merror[39m: Caught by controller[20]: 2018-10-02T16:00:42.457Z engine.io-client:socket creating transport "websocket"
2018-10-02 18:00:49.292  - [31merror[39m: Caught by controller[21]: 2018-10-02T16:00:42.483Z engine.io-client:socket socket receive: type "message", data "0"
2018-10-02 18:00:49.293  - [31merror[39m: Caught by controller[22]: 2018-10-02T16:00:42.490Z socket.io-parser decoded 0 as {"type":0,"nsp":"/"}
2018-10-02 18:00:49.293  - [31merror[39m: Caught by controller[23]: 2018-10-02T16:00:42.527Z engine.io-client:polling polling
2018-10-02 18:00:49.293  - [31merror[39m: Caught by controller[24]: 2018-10-02T16:00:42.527Z engine.io-client:polling-xhr xhr poll
2018-10-02 18:00:49.294  - [31merror[39m: Caught by controller[25]: 2018-10-02T16:00:42.529Z engine.io-client:polling-xhr xhr open GET: http://127.0.0.1:9001/socket.io/?EIO=3&transport=polling&t=MOrWfOW&b64=1&sid=hqP-Ug2UiFlPpWXMAABZ
2018-10-02 18:00:49.294  - [31merror[39m: Caught by controller[26]: 2018-10-02T16:00:42.530Z engine.io-client:polling-xhr xhr data null
2018-10-02 18:00:49.294  - [31merror[39m: Caught by controller[27]: 2018-10-02T16:00:42.598Z engine.io-client:socket probe transport "websocket" opened
2018-10-02 18:00:49.295  - [31merror[39m: Caught by controller[28]: 2018-10-02T16:00:42.647Z engine.io-client:socket probe transport "websocket" pong
2018-10-02 18:00:49.295  - [31merror[39m: Caught by controller[29]: 2018-10-02T16:00:42.648Z engine.io-client:socket pausing current transport "polling"
2018-10-02 18:00:49.295  - [31merror[39m: Caught by controller[30]: 2018-10-02T16:00:42.649Z engine.io-client:polling we are currently polling - waiting to pause
2018-10-02 18:00:49.296  - [31merror[39m: Caught by controller[31]: 2018-10-02T16:00:42.655Z socket.io-client:socket emitting packet with ack id 0
2018-10-02 18:00:49.296  - [31merror[39m: Caught by controller[32]: 2018-10-02T16:00:42.656Z socket.io-client:manager writing packet {"type":2,"data":["getObject","system.adapter.yahka.0",null],"options":{"compress":true},"id":0,"nsp":"/"}
2018-10-02 18:00:49.296  - [31merror[39m: Caught by controller[33]: 2018-10-02T16:00:42.657Z socket.io-parser encoding packet {"type":2,"data":["getObject","system.adapter.yahka.0",null],"options":{"compress":true},"id":0,"nsp":"/"}
2018-10-02 18:00:49.297  - [31merror[39m: Caught by controller[34]: 2018-10-02T16:00:42.659Z socket.io-parser encoded {"type":2,"data":["getObject","system.adapter.yahka.0",null],"options":{"compress":true},"id":0,"nsp":"/"} as 20["getObject","system.adapter.yahka.0",null]
2018-10-02 18:00:49.297  - [31merror[39m: Caught by controller[35]: 2018-10-02T16:00:42.713Z engine.io-client:polling polling got data 1:6
2018-10-02 18:00:49.297  - [31merror[39m: Caught by controller[36]: 2018-10-02T16:00:42.714Z engine.io-client:socket socket receive: type "noop", data "undefined"
2018-10-02 18:00:49.298  - [31merror[39m: Caught by controller[37]: 2018-10-02T16:00:42.716Z engine.io-client:polling pre-pause polling complete
2018-10-02 18:00:49.298  - [31merror[39m: Caught by controller[38]: 2018-10-02T16:00:42.716Z engine.io-client:polling paused
2018-10-02 18:00:49.298  - [31merror[39m: Caught by controller[39]: 2018-10-02T16:00:42.717Z engine.io-client:socket changing transport and sending upgrade packet
2018-10-02 18:00:49.298  - [31merror[39m: Caught by controller[40]: 2018-10-02T16:00:42.718Z engine.io-client:socket setting transport websocket
2018-10-02 18:00:49.299  - [31merror[39m: Caught by controller[41]: 2018-10-02T16:00:42.719Z engine.io-client:socket clearing existing transport polling
2018-10-02 18:00:49.299  - [31merror[39m: Caught by controller[42]: 2018-10-02T16:00:42.722Z engine.io-client:polling ignoring poll - transport state "paused"
2018-10-02 18:00:49.299  - [31merror[39m: Caught by controller[43]: 2018-10-02T16:00:42.724Z engine.io-client:socket flushing 1 packets in socket
2018-10-02 18:00:49.300  - [31merror[39m: Caught by controller[44]: 2018-10-02T16:00:42.748Z engine.io-client:socket socket receive: type "message", data "30[null,{"_id":"system.adapter.yahka.0","type":"instance","common":{"name":"yahka","version":"0.8.0","news":{"0.7.1":{"en":"Fixed the ID select dialog in Admin 2.0.9. restructured repo to allow install via git-url","de":"Der ID-Auswahldialog in Admin 2.0.9 wurde korrigiert. Repository umstrukturiert um Installation via git-url zu ermöglichen"},"0.7.0":{"en":"Fixed the ID select dialog in Admin3, added new services and fixed some other bugs","de":"Der ID-Auswahldialog in Admin3 wurde korrigiert, neue Dienste hinzugefügt und kleinere Fehler behoben","ru":"Исправлено диалоговое окно выбора идентификатора в Admin3","pt":"Corrigido o diálogo de seleção de ID em Admin3","nl":"Vaste het ID selectiedialoog in Admin3","fr":"Correction du dialogue de sélection d'ID dans Admin3","it":"Risolta la finestra di dialogo di selezione dell'ID in Admin3","es":"Se corrigió el diálogo de selección de ID en Admin3","pl":"Naprawiono okno dialogowe wyboru identyfikatora w Admin3"},"0.6.1":{"en":"Fixed a bug which prevent Yahka from Start","de":"Fixed a bug which prevent Yahka from Start","ru":"Fixed a bug which prevent Yahka from Start"},"0.6.0":{"en":"Support for IP-Cameras","de":"Support für IP-Kameras","ru":"Поддержка IP-Камер"},"0.5.5":{"en":"Make a config dialog bigger","de":"Config-Dialog ist vergrößert","ru":"Увеличен размер окна настроек"},"0.8.0":{"en":"ScaleInt and ScaleFloat now support a min-parameter to improve mapping of values. Added 'Duplicate Device' to Admin interface.","de":"ScaleInt und ScaleFloat untersützen nun die Angabe eines Min-Parameters. 'Gerät duplizieren' zu Admin Oberfläche hinzugefügt."}},"title":"Homekit","desc":{"en":"yet another Homekit adapter","de":"noch ein weiterer Homekit-Adapter","ru":"Homekit драйвер","pt":"ainda outro adaptador Homekit","nl":"nog een andere Homekit-adapter","fr":"encore un autre adaptateur Homekit","it":"ancora un altro adattatore Homekit","es":"otro adaptador para el Homekit","pl":"kolejny adapter Homekit"},"platform":"Javascript/Node.js","mode":"daemon","icon":"yahka.png","enabled":true,"extIcon":"https://raw.githubusercontent.com/jensweigele/ioBroker.yahka/master/admin/yahka.png","keywords":["homekit","siri"],"readme":"https://github.com/jensweigele/ioBroker.yahka/blob/master/README.md","loglevel":"info","type":"iot-systems","materialize":true,"config":{"minWidth":800,"width ":1440,"minHeight":600,"height ":860},"authors":[{"name":"Jens Weigele","email":"iobroker.yahka@gmail.com"}],"installedVersion":"0.8.0","host":"ioBroker-Rock64"},"native":{"firstTimeInitialized":true,"bridge":{"devices":[{"configType":"customdevice","manufacturer":"Homematic","model":"Keymatic","name":"Haustüre","serial":"","enabled":true,"category":"6","services":[{"name":"Türöffner","subType":"","type":"Switch","characteristics":[{"name":"On","enabled":true,"inOutFunction":"ioBroker.State","inOutParameters":"hm-rpc.0.OEQ0313814.1.OPEN"}]},{"name":"Haustür","subType":"","type":"Door","characteristics":[{"name":"CurrentPosition","enabled":true,"inOutFunction":"ioBroker.State","inOutParameters":"hm-rpc.0.OEQ0313814.1.STATE"},{"name":"TargetPosition","enabled":true,"inOutFunction":"ioBroker.State","inOutParameters":"hm-rpc.0.OEQ0313814.1.STATE"}]}]}],"ident":":yahka.0","name":"iobroker","serial":":yahka.0","username":"20:36:51:eb:32:01","pincode":"063-45-679","port":0,"verboseLogging":false,"configType":"bridge","manufacturer":"ioBroker","model":"Pi"},"cameras":[]},"from":"system.adapter.admin.0","ts":1538496040321,"acl":{"object":1636,"owner":"system.user.admin","ownerGroup":"system.group.administrator"}}]"
2018-10-02 18:00:49.300  - [31merror[39m: Caught by controller[45]: 2018-10-02T16:00:42.751Z socket.io-parser decoded 30[null,{"_id":"system.adapter.yahka.0","type":"instance","common":{"name":"yahka","version":"0.8.0","news":{"0.7.1":{"en":"Fixed the ID select dialog in Admin 2.0.9. restructured repo to allow install via git-url","de":"Der ID-Auswahldialog in Admin 2.0.9 wurde korrigiert. Repository umstrukturiert um Installation via git-url zu ermöglichen"},"0.7.0":{"en":"Fixed the ID select dialog in Admin3, added new services and fixed some other bugs","de":"Der ID-Auswahldialog in Admin3 wurde korrigiert, neue Dienste hinzugefügt und kleinere Fehler behoben","ru":"Исправлено диалоговое окно выбора идентификатора в Admin3","pt":"Corrigido o diálogo de seleção de ID em Admin3","nl":"Vaste het ID selectiedialoog in Admin3","fr":"Correction du dialogue de sélection d'ID dans Admin3","it":"Risolta la finestra di dialogo di selezione dell'ID in Admin3","es":"Se corrigió el diálogo de selección de ID en Admin3","pl":"Naprawiono okno dialogowe wyboru identyfikatora w Admin3"},"0.6.1":{"en":"Fixed a bug which prevent Yahka from Start","de":"Fixed a bug which prevent Yahka from Start","ru":"Fixed a bug which prevent Yahka from Start"},"0.6.0":{"en":"Support for IP-Cameras","de":"Support für IP-Kameras","ru":"Поддержка IP-Камер"},"0.5.5":{"en":"Make a config dialog bigger","de":"Config-Dialog ist vergrößert","ru":"Увеличен размер окна настроек"},"0.8.0":{"en":"ScaleInt and ScaleFloat now support a min-parameter to improve mapping of values. Added 'Duplicate Device' to Admin interface.","de":"ScaleInt und ScaleFloat untersützen nun die Angabe eines Min-Parameters. 'Gerät duplizieren' zu Admin Oberfläche hinzugefügt."}},"title":"Homekit","desc":{"en":"yet another Homekit adapter","de":"noch ein weiterer Homekit-Adapter","ru":"Homekit драйвер","pt":"ainda outro adaptador Homekit","nl":"nog een andere Homekit-adapter","fr":"encore un autre adaptateur Homekit","it":"ancora un altro adattatore Homekit","es":"otro adaptador para el Homekit","pl":"kolejny adapter Homekit"},"platform":"Javascript/Node.js","mode":"daemon","icon":"yahka.png","enabled":true,"extIcon":"https://raw.githubusercontent.com/jensweigele/ioBroker.yahka/master/admin/yahka.png","keywords":["homekit","siri"],"readme":"https://github.com/jensweigele/ioBroker.yahka/blob/master/README.md","loglevel":"info","type":"iot-systems","materialize":true,"config":{"minWidth":800,"width ":1440,"minHeight":600,"height ":860},"authors":[{"name":"Jens Weigele","email":"iobroker.yahka@gmail.com"}],"installedVersion":"0.8.0","host":"ioBroker-Rock64"},"native":{"firstTimeInitialized":true,"bridge":{"devices":[{"configType":"customdevice","manufacturer":"Homematic","model":"Keymatic","name":"Haustüre","serial":"","enabled":true,"category":"6","services":[{"name":"Türöffner","subType":"","type":"Switch","characteristics":[{"name":"On","enabled":true,"inOutFunction":"ioBroker.State","inOutParameters":"hm-rpc.0.OEQ0313814.1.OPEN"}]},{"name":"Haustür","subType":"","type":"Door","characteristics":[{"name":"CurrentPosition","enabled":true,"inOutFunction":"ioBroker.State","inOutParameters":"hm-rpc.0.OEQ0313814.1.STATE"},{"name":"TargetPosition","enabled":true,"inOutFunction":"ioBroker.State","inOutParameters":"hm-rpc.0.OEQ0313814.1.STATE"}]}]}],"ident":":yahka.0","name":"iobroker","serial":":yahka.0","username":"20:36:51:eb:32:01","pincode":"063-45-679","port":0,"verboseLogging":false,"configType":"bridge","manufacturer":"ioBroker","model":"Pi"},"cameras":[]},"from":"system.adapter.admin.0","ts":1538496040321,"acl":{"object":1636,"owner":"system.user.admin","ownerGroup":"system.group.administrator"}}] as {"type":3,"nsp":"/","id":0,"data":[null,{"_id":"system.adapter.yahka.0","type":"instance","common":{"name":"yahka","version":"0.8.0","news":{"0.7.1":{"en":"Fixed the ID select dialog in Admin 2.0.9. restructured repo to allow install via git-url","de":"Der ID-Auswahldialog in Admin 2.0.9 wurde korrigiert. Repository umstrukturiert um Installation via git-url zu ermöglichen"},"0.7.0":{"en":"Fixed the ID select dialog in Admin3, added new services and fixed some other bugs","de":"Der ID-Auswahldialog in Admin3 wurde korrigiert, neue Dienste hinzugefügt und kleinere Fehler behoben","ru":"Исправлено диалоговое окно выбора идентификатора в Admin3","pt":"Corrigido o diálogo de seleção de ID em Admin3","nl":"Vaste het ID selectiedialoog in Admin3","fr":"Correction du dialogue de sélection d'ID dans Admin3","it":"Risolta la finestra di dialogo di selezione dell'ID in Admin3","es":"Se corrigió el diálogo de selección de ID en Admin3","pl":"Naprawiono okno dialogowe wyboru identyfikatora w Admin3"},"0.6.1":{"en":"Fixed a bug which prevent Yahka from Start","de":"Fixed a bug which prevent Yahka from Start","ru":"Fixed a bug which prevent Yahka from Start"},"0.6.0":{"en":"Support for IP-Cameras","de":"Support für IP-Kameras","ru":"Поддержка IP-Камер"},"0.5.5":{"en":"Make a config dialog bigger","de":"Config-Dialog ist vergrößert","ru":"Увеличен размер окна настроек"},"0.8.0":{"en":"ScaleInt and ScaleFloat now support a min-parameter to improve mapping of values. Added 'Duplicate Device' to Admin interface.","de":"ScaleInt und ScaleFloat untersützen nun die Angabe eines Min-Parameters. 'Gerät duplizieren' zu Admin Oberfläche hinzugefügt."}},"title":"Homekit","desc":{"en":"yet another Homekit adapter","de":"noch ein weiterer Homekit-Adapter","ru":"Homekit драйвер","pt":"ainda outro adaptador Homekit","nl":"nog een andere Homekit-adapter","fr":"encore un autre adaptateur Homekit","it":"ancora un altro adattatore Homekit","es":"otro adaptador para el Homekit","pl":"kolejny adapter Homekit"},"platform":"Javascript/Node.js","mode":"daemon","icon":"yahka.png","enabled":true,"extIcon":"https://raw.githubusercontent.com/jensweigele/ioBroker.yahka/master/admin/yahka.png","keywords":["homekit","siri"],"readme":"https://github.com/jensweigele/ioBroker.yahka/blob/master/README.md","loglevel":"info","type":"iot-systems","materialize":true,"config":{"minWidth":800,"width ":1440,"minHeight":600,"height ":860},"authors":[{"name":"Jens Weigele","email":"iobroker.yahka@gmail.com"}],"installedVersion":"0.8.0","host":"ioBroker-Rock64"},"native":{"firstTimeInitialized":true,"bridge":{"devices":[{"configType":"customdevice","manufacturer":"Homematic","model":"Keymatic","name":"Haustüre","serial":"","enabled":true,"category":"6","services":[{"name":"Türöffner","subType":"","type":"Switch","characteristics":[{"name":"On","enabled":true,"inOutFunction":"ioBroker.State","inOutParameters":"hm-rpc.0.OEQ0313814.1.OPEN"}]},{"name":"Haustür","subType":"","type":"Door","characteristics":[{"name":"CurrentPosition","enabled":true,"inOutFunction":"ioBroker.State","inOutParameters":"hm-rpc.0.OEQ0313814.1.STATE"},{"name":"TargetPosition","enabled":true,"inOutFunction":"ioBroker.State","inOutParameters":"hm-rpc.0.OEQ0313814.1.STATE"}]}]}],"ident":":yahka.0","name":"iobroker","serial":":yahka.0","username":"20:36:51:eb:32:01","pincode":"063-45-679","port":0,"verboseLogging":false,"configType":"bridge","manufacturer":"ioBroker","model":"Pi"},"cameras":[]},"from":"system.adapter.admin.0","ts":1538496040321,"acl":{"object":1636,"owner":"system.user.admin","ownerGroup":"system.group.administrator"}}]}
2018-10-02 18:00:49.301  - [31merror[39m: Caught by controller[46]: 2018-10-02T16:00:42.752Z socket.io-client:socket calling ack 0 with [null,{"_id":"system.adapter.yahka.0","type":"instance","common":{"name":"yahka","version":"0.8.0","news":{"0.7.1":{"en":"Fixed the ID select dialog in Admin 2.0.9. restructured repo to allow install via git-url","de":"Der ID-Auswahldialog in Admin 2.0.9 wurde korrigiert. Repository umstrukturiert um Installation via git-url zu ermöglichen"},"0.7.0":{"en":"Fixed the ID select dialog in Admin3, added new services and fixed some other bugs","de":"Der ID-Auswahldialog in Admin3 wurde korrigiert, neue Dienste hinzugefügt und kleinere Fehler behoben","ru":"Исправлено диалоговое окно выбора идентификатора в Admin3","pt":"Corrigido o diálogo de seleção de ID em Admin3","nl":"Vaste het ID selectiedialoog in Admin3","fr":"Correction du dialogue de sélection d'ID dans Admin3","it":"Risolta la finestra di dialogo di selezione dell'ID in Admin3","es":"Se corrigió el diálogo de selección de ID en Admin3","pl":"Naprawiono okno dialogowe wyboru identyfikatora w Admin3"},"0.6.1":{"en":"Fixed a bug which prevent Yahka from Start","de":"Fixed a bug which prevent Yahka from Start","ru":"Fixed a bug which prevent Yahka from Start"},"0.6.0":{"en":"Support for IP-Cameras","de":"Support für IP-Kameras","ru":"Поддержка IP-Камер"},"0.5.5":{"en":"Make a config dialog bigger","de":"Config-Dialog ist vergrößert","ru":"Увеличен размер окна настроек"},"0.8.0":{"en":"ScaleInt and ScaleFloat now support a min-parameter to improve mapping of values. Added 'Duplicate Device' to Admin interface.","de":"ScaleInt und ScaleFloat untersützen nun die Angabe eines Min-Parameters. 'Gerät duplizieren' zu Admin Oberfläche hinzugefügt."}},"title":"Homekit","desc":{"en":"yet another Homekit adapter","de":"noch ein weiterer Homekit-Adapter","ru":"Homekit драйвер","pt":"ainda outro adaptador Homekit","nl":"nog een andere Homekit-adapter","fr":"encore un autre adaptateur Homekit","it":"ancora un altro adattatore Homekit","es":"otro adaptador para el Homekit","pl":"kolejny adapter Homekit"},"platform":"Javascript/Node.js","mode":"daemon","icon":"yahka.png","enabled":true,"extIcon":"https://raw.githubusercontent.com/jensweigele/ioBroker.yahka/master/admin/yahka.png","keywords":["homekit","siri"],"readme":"https://github.com/jensweigele/ioBroker.yahka/blob/master/README.md","loglevel":"info","type":"iot-systems","materialize":true,"config":{"minWidth":800,"width ":1440,"minHeight":600,"height ":860},"authors":[{"name":"Jens Weigele","email":"iobroker.yahka@gmail.com"}],"installedVersion":"0.8.0","host":"ioBroker-Rock64"},"native":{"firstTimeInitialized":true,"bridge":{"devices":[{"configType":"customdevice","manufacturer":"Homematic","model":"Keymatic","name":"Haustüre","serial":"","enabled":true,"category":"6","services":[{"name":"Türöffner","subType":"","type":"Switch","characteristics":[{"name":"On","enabled":true,"inOutFunction":"ioBroker.State","inOutParameters":"hm-rpc.0.OEQ0313814.1.OPEN"}]},{"name":"Haustür","subType":"","type":"Door","characteristics":[{"name":"CurrentPosition","enabled":true,"inOutFunction":"ioBroker.State","inOutParameters":"hm-rpc.0.OEQ0313814.1.STATE"},{"name":"TargetPosition","enabled":true,"inOutFunction":"ioBroker.State","inOutParameters":"hm-rpc.0.OEQ0313814.1.STATE"}]}]}],"ident":":yahka.0","name":"iobroker","serial":":yahka.0","username":"20:36:51:eb:32:01","pincode":"063-45-679","port":0,"verboseLogging":false,"configType":"bridge","manufacturer":"ioBroker","model":"Pi"},"cameras":[]},"from":"system.adapter.admin.0","ts":1538496040321,"acl":{"object":1636,"owner":"system.user.admin","ownerGroup":"system.group.administrator"}}]
2018-10-02 18:00:49.302  - [31merror[39m: Caught by controller[47]: 2018-10-02T16:00:42.821Z socket.io-client:socket emitting packet with ack id 1
2018-10-02 18:00:49.302  - [31merror[39m: Caught by controller[48]: 2018-10-02T16:00:42.821Z socket.io-client:manager writing packet {"type":2,"data":["getObjectView","system","instance",{"startkey":"system.adapter.","endkey":"system.adapter.香"},{"name":"yahka","systemConfig":true}],"options":{"compress":true},"id":1,"nsp":"/"}
2018-10-02 18:00:49.302  - [31merror[39m: Caught by controller[49]: 2018-10-02T16:00:42.822Z socket.io-parser encoding packet {"type":2,"data":["getObjectView","system","instance",{"startkey":"system.adapter.","endkey":"system.adapter.香"},{"name":"yahka","systemConfig":true}],"options":{"compress":true},"id":1,"nsp":"/"}
2018-10-02 18:00:49.303  - [31merror[39m: Caught by controller[50]: 2018-10-02T16:00:42.823Z socket.io-parser encoded {"type":2,"data":["getObjectView","system","instance",{"startkey":"system.adapter.","endkey":"system.adapter.香"},{"name":"yahka","systemConfig":true}],"options":{"compress":true},"id":1,"nsp":"/"} as 21["getObjectView","system","instance",{"startkey":"system.adapter.","endkey":"system.adapter.香"},{"name":"yahka","systemConfig":true}]
2018-10-02 18:00:49.303  - [31merror[39m: Caught by controller[51]: 2018-10-02T16:00:42.824Z engine.io-client:socket flushing 1 packets in socket
2018-10-02 18:00:49.303  - [31merror[39m: Caught by controller[52]: 2018-10-02T16:00:42.826Z socket.io-client:manager writing packet {"type":2,"data":["subscribe","system.adapter.*",null],"options":{"compress":true},"nsp":"/"}
2018-10-02 18:00:49.304  - [31merror[39m: Caught by controller[52]: 2018-10-02T16:00:42.827Z socket.io-parser encoding packet {"type":2,"data":["subscribe","system.adapter.*",null],"options":{"compress":true},"nsp":"/"}
2018-10-02 18:00:49.304  - [31merror[39m: Caught by controller[52]: 2018-10-02T16:00:42.828Z socket.io-parser encoded {"type":2,"data":["subscribe","system.adapter.*",null],"options":{"compress":true},"nsp":"/"} as 2["subscribe","system.adapter.*",null]
2018-10-02 18:00:49.304  - [31merror[39m: Caught by controller[52]: 2018-10-02T16:00:42.836Z socket.io-client:socket emitting packet with ack id 2
2018-10-02 18:00:49.305  - [31merror[39m: Caught by controller[52]: 2018-10-02T16:00:42.836Z socket.io-client:manager writing packet {"type":2,"data":["getObjectView","system","instance",{"startkey":"system.adapter.","endkey":"system.adapter.香"},{"name":"yahka","systemConfig":true}],"options":{"compress":true},"id":2,"nsp":"/"}
2018-10-02 18:00:49.305  - [31merror[39m: Caught by controller[52]: 2018-10-02T16:00:42.837Z socket.io-parser encoding packet {"type":2,"data":["getObjectView","system","instance",{"startkey":"system.adapter.","endkey":"system.adapter.香"},{"name":"yahka","systemConfig":true}],"options":{"compress":true},"id":2,"nsp":"/"}
2018-10-02 18:00:49.305  - [31merror[39m: Caught by controller[52]: 2018-10-02T16:00:42.837Z socket.io-parser encoded {"type":2,"data":["getObjectView","system","instance",{"startkey":"system.adapter.","endkey":"system.adapter.香"},{"name":"yahka","systemConfig":true}],"options":{"compress":true},"id":2,"nsp":"/"} as 22["getObjectView","system","instance",{"startkey":"system.adapter.","endkey":"system.adapter.香"},{"name":"yahka","systemConfig":true}]
2018-10-02 18:00:49.306  - [31merror[39m: Caught by controller[52]: 2018-10-02T16:00:42.838Z socket.io-client:manager writing packet {"type":2,"data":["subscribe","system.adapter.*",null],"options":{"compress":true},"nsp":"/"}
2018-10-02 18:00:49.306  - [31merror[39m: Caught by controller[52]: 2018-10-02T16:00:42.839Z socket.io-parser encoding packet {"type":2,"data":["subscribe","system.adapter.*",null],"options":{"compress":true},"nsp":"/"}
2018-10-02 18:00:49.306  - [31merror[39m: Caught by controller[52]: 2018-10-02T16:00:42.839Z socket.io-parser encoded {"type":2,"data":["subscribe","system.adapter.*",null],"options":{"compress":true},"nsp":"/"} as 2["subscribe","system.adapter.*",null]
2018-10-02 18:00:49.306  - [31merror[39m: Caught by controller[52]: 2018-10-02T16:00:42.840Z socket.io-client:socket emitting packet with ack id 3
2018-10-02 18:00:49.307  - [31merror[39m: Caught by controller[52]: 2018-10-02T16:00:42.841Z socket.io-client:manager writing packet {"type":2,"data":["getObjectView","system","instance",{"startkey":"system.adapter.","endkey":"system.adapter.香"},{"name":"yahka","systemConfig":true}],"options":{"compress":true},"id":3,"nsp":"/"}
2018-10-02 18:00:49.307  - [31merror[39m: Caught by controller[52]: 2018-10-02T16:00:42.841Z socket.io-parser encoding packet {"type":2,"data":["getObjectView","system","instance",{"startkey":"system.adapter.","endkey":"system.adapter.香"},{"name":"yahka","systemConfig":true}],"options":{"compress":true},"id":3,"nsp":"/"}
2018-10-02 18:00:49.307  - [31merror[39m: Caught by controller[52]: 2018-10-02T16:00:42.842Z socket.io-parser encoded {"type":2,"data":["getObjectView","system","instance",{"startkey":"system.adapter.","endkey":"system.adapter.香"},
```
and so on