### PR TITLE
change "scaleInt" conversion to round values

### DIFF
--- a/src/yahka.functions/conversion.scale.int.ts
+++ b/src/yahka.functions/conversion.scale.int.ts
@@ -1,0 +1,17 @@
+import { TIoBrokerConversion_Scale } from './conversion.scale';
+
+export class TIoBrokerConversion_Scale_Int extends TIoBrokerConversion_Scale {
+    /**
+     * @override
+     */
+    toHomeKit(value) {
+        return Math.round(super.toHomeKit(value));
+    }
+
+    /**
+     * @override
+     */
+    toIOBroker(value) {
+        return Math.round(super.toIOBroker(value));
+    }
+}

--- a/src/yahka.functions/conversion.scale.ts
+++ b/src/yahka.functions/conversion.scale.ts
@@ -36,7 +36,7 @@ export class TIoBrokerConversion_Scale extends TIOBrokerConversionBase implement
         let ioBrokerMin = this.parameters["iobroker.min"];
         let newValue = ((num - ioBrokerMin) / (ioBrokerMax - ioBrokerMin)) * (homeKitMax - homeKitMin) + homeKitMin;
         this.adapter.log.debug(`${this.logName}: converting value to homekit: ${value} to ${newValue}`);
-        return this.logName === "scaleInt" ? Math.round(newValue) : newValue;
+        return newValue;
     }
     toIOBroker(value) {
         let num: number = TIOBrokerConversionBase.castToNumber(value);
@@ -46,6 +46,6 @@ export class TIoBrokerConversion_Scale extends TIOBrokerConversionBase implement
         let ioBrokerMin = this.parameters["iobroker.min"];
         let newValue = ((num - homeKitMin) / (homeKitMax - homeKitMin)) * (ioBrokerMax - ioBrokerMin) + ioBrokerMin;
         this.adapter.log.debug(`${this.logName}: converting value to ioBroker: ${value} to ${newValue}`);
-        return this.logName === "scaleInt" ? Math.round(newValue) : newValue;
+        return newValue;
     }
 }

--- a/src/yahka.functions/conversion.scale.ts
+++ b/src/yahka.functions/conversion.scale.ts
@@ -36,7 +36,7 @@ export class TIoBrokerConversion_Scale extends TIOBrokerConversionBase implement
         let ioBrokerMin = this.parameters["iobroker.min"];
         let newValue = ((num - ioBrokerMin) / (ioBrokerMax - ioBrokerMin)) * (homeKitMax - homeKitMin) + homeKitMin;
         this.adapter.log.debug(`${this.logName}: converting value to homekit: ${value} to ${newValue}`);
-        return newValue;
+        return this.logName === "scaleInt" ? Math.round(newValue) : newValue;
     }
     toIOBroker(value) {
         let num: number = TIOBrokerConversionBase.castToNumber(value);
@@ -46,6 +46,6 @@ export class TIoBrokerConversion_Scale extends TIOBrokerConversionBase implement
         let ioBrokerMin = this.parameters["iobroker.min"];
         let newValue = ((num - homeKitMin) / (homeKitMax - homeKitMin)) * (ioBrokerMax - ioBrokerMin) + ioBrokerMin;
         this.adapter.log.debug(`${this.logName}: converting value to ioBroker: ${value} to ${newValue}`);
-        return newValue;
+        return this.logName === "scaleInt" ? Math.round(newValue) : newValue;
     }
 }

--- a/src/yahka.functions/functions.import.ts
+++ b/src/yahka.functions/functions.import.ts
@@ -5,6 +5,7 @@ import { TIoBrokerInOutFunction_HomematicWindowCovering_TargetPosition } from '.
 import { TIoBrokerConversion_Passthrough } from './conversion.passthrough';
 import { TIoBrokerConversion_HomematicControlMode_To_CoolingState, TIoBrokerConversion_HomematicDirection_To_PositionState } from './conversion.homekit.homematic';
 import { TIoBrokerConversion_Scale } from './conversion.scale';
+import { TIoBrokerConversion_Scale_Int } from './conversion.scale.int';
 import { TIoBrokerConversion_Inverse } from './conversion.inverse';
 import { TIoBrokerConversion_Script } from './conversion.script';
 import { TIoBrokerInOutFunction_MultiState } from './iofunc.multi-state';
@@ -29,7 +30,7 @@ conversionFactory["level255"] = (adapter, param) => new TIoBrokerConversion_Scal
     "iobroker.min": 0,
     "iobroker.max": 255
 }, 'level255');
-conversionFactory["scaleInt"] = (adapter, param) => new TIoBrokerConversion_Scale(adapter, param, 'scaleInt');
+conversionFactory["scaleInt"] = (adapter, param) => new TIoBrokerConversion_Scale_Int(adapter, param, 'scaleInt');
 conversionFactory["scaleFloat"] = (adapter, param) => new TIoBrokerConversion_Scale(adapter, param, 'scaleFloat');
 conversionFactory["hue"] = (adapter, param) => new TIoBrokerConversion_Scale(adapter, {
     "homekit.min": 0,


### PR DESCRIPTION
Hi

I use the Hue-extended adapter and it seems that this adapter needs integers values to function.
In the yahka adapter exists a conversion function with name "scaleInt", i think it should convert to integer, but the math calculation produces float values. So I added an Math.round() to the calculated value if the conversion function name is "scaleInt".

What do you think?