### PR TITLE
multi-state: do not compare to previous state

### DIFF
--- a/src/yahka.functions/iofunc.multi-state.ts
+++ b/src/yahka.functions/iofunc.multi-state.ts
@@ -55,21 +55,12 @@ export class TIoBrokerInOutFunction_MultiState extends TIoBrokerInOutFunctionBas
         return new Promise<void>((resolve, reject) => {
             let stateName = state.writeState || state.readState;
             this.log.debug('writing state to ioBroker [' + stateName + ']: ' + JSON.stringify(newValue));
-            this.adapter.getForeignState(stateName, (error, ioState) => {
-                let value = ioState?.val;
-                let valueChanged = value !== newValue;
-                this.log.debug('checking value change: ' + JSON.stringify(value) + ' != ' + JSON.stringify(newValue) + ' = ' + valueChanged);
-                if (valueChanged) {
-                    this.adapter.setForeignState(stateName, newValue, false, (error) => {
-                        if (error) {
-                            this.log.error('setForeignState error [' + stateName + '] to [' + JSON.stringify(newValue) + ']: ' + error);
-                            reject(error);
-                        }
-                        resolve();
-                    });
-                } else {
-                    resolve();
+            this.adapter.setForeignState(stateName, newValue, false, (error) => {
+                if (error) {
+                    this.log.error('setForeignState error [' + stateName + '] to [' + JSON.stringify(newValue) + ']: ' + error);
+                    reject(error);
                 }
+                resolve();
             });
         });
     }


### PR DESCRIPTION
In iofunc.multi-state.js: When setting a MultiState, do not compare to the previous value as it might not reflect the true state of the MultiState. Instead, just set the state regardless. This solves issues with MultiStates where two distinct objects are used for a single state (e.g. in KNX installations where it is common to use a feedback object from the actor itself instead of relying on the state send by a switch).