### PR TITLE
Fix Debian package name for PAM headers: pam-devel -> libpam0g-dev

### DIFF
--- a/io-package.json
+++ b/io-package.json
@@ -199,7 +199,7 @@
     "osDependencies": {
       "linux": [
         "libavahi-compat-libdnssd-dev",
-        "pam-devel"
+        "libpam0g-dev"
       ]
     },
     "dependencies": [


### PR DESCRIPTION
The linux osDependencies list contains "pam-devel", which is the RedHat/Fedora package name. On Debian and Ubuntu - where most ioBroker installations run - no such package exists, so the adapter installation fails with: "The following apt packages could not be installed: pam-devel". The correct Debian package providing security/pam_appl.h is libpam0g-dev. The neighbouring entry libavahi-compat-libdnssd-dev is itself a Debian-only name (RedHat calls it avahi-compat-libdns_sd-devel), so the list is clearly meant for apt. Reported since 2018 in #80 and #83 and in several forum threads.

---

**Auf Deutsch:** In `osDependencies` steht für Linux das Paket `pam-devel`. Das ist der RedHat/Fedora-Name — unter Debian und Ubuntu gibt es dieses Paket nicht, dort heißt es `libpam0g-dev`. Die Adapter-Installation bricht deshalb ab mit „The following apt packages could not be installed: pam-devel". Dass die Liste für `apt` gedacht ist, zeigt der Nachbareintrag `libavahi-compat-libdnssd-dev` — auch das ist ein reiner Debian-Name. Gemeldet wurde das seit 2018 mehrfach (#80, #83 und diverse Forum-Threads), der Fix ist diese eine Zeile. Getestet auf Debian 13 (Trixie): Nach `apt install libpam0g-dev` installiert und startet der Adapter einwandfrei.